### PR TITLE
[Classic] Fix error when clicking friend in online list

### DIFF
--- a/TitanSocial.lua
+++ b/TitanSocial.lua
@@ -990,7 +990,7 @@ local function addFriends(tooltip, collapseVar)
 		end
 
 		local y = tooltip:AddLine(check, level, left, right)
-		tooltip:SetLineScript(y, "OnMouseDown", clickPlayer, { origname, false, false, false })
+		tooltip:SetLineScript(y, "OnMouseDown", clickPlayer, { info.name, false, false, false })
 	end
 end
 


### PR DESCRIPTION
Fixes this:

```
3x FrameXML\ChatFrame.lua:3648: attempt to concatenate local 'name' (a nil value)
FrameXML\ChatFrame.lua:3648: in function <FrameXML\ChatFrame.lua:3640>
TitanSocial\TitanSocial-1.13.3.lua:545: in function `handler'
TitanSocial\tooltip.lua:498: in function <TitanSocial\tooltip.lua:486>
TitanSocial\tooltip.lua:530: in function <TitanSocial\tooltip.lua:529>

Locals:
name = nil
chatFrame = nil
editBox = ChatFrame1EditBox {
 0 = <userdata>
 addSpaceToAutoComplete = true
 tabCompleteTableIndex = 1
 headerSuffix = ChatFrame1EditBoxHeaderSuffix {
 }
 setText = 0
 Backdrop = <unnamed> {
 }
 customAutoCompleteFunction = <function> defined @FrameXML\ChatFrame.lua:3898
 text = "/"
 chatFrame = ChatFrame1 {
 }
 header = ChatFrame1EditBoxHeader {
 }
 addHighlightedText = true
 autoCompleteParams = <table> {
 }
 languageID = 7
 language = "Common"
}
(*temporary) = <function> defined @FrameXML\ChatFrame.lua:3563
(*temporary) = "/cw"
(*temporary) = " "
(*temporary) = nil
(*temporary) = " "
(*temporary) = nil
(*temporary) = "attempt to concatenate local 'name' (a nil value)"
```